### PR TITLE
fix requirements.txt error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ huggingface_hub
 pytz
 click
 pydantic==1.10.11
-fschat=git+https://github.com/lm-sys/FastChat@v0.2.25
+git+https://github.com/lm-sys/FastChat@v0.2.25
 git+https://github.com/DachengLi1/LongChat@0a4d022


### PR DESCRIPTION
fix ERROR: Invalid requirement: 'fschat=git+https://github.com/lm-sys/FastChat@v0.2.25' (from line 8 of requirements.txt)
Hint: It looks like a path. File 'fschat=git+https://github.com/lm-sys/FastChat@v0.2.25' does not exist.